### PR TITLE
includes : disable static checks when using polymorphic relations

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -305,7 +305,12 @@ module FastJsonapi
             relationships_to_serialize = klass.relationships_to_serialize || {}
             relationship_to_include = relationships_to_serialize[parsed_include]
             raise ArgumentError, "#{parsed_include} is not specified as a relationship on #{klass.name}" unless relationship_to_include
-            klass = relationship_to_include.serializer.to_s.constantize unless relationship_to_include.polymorphic.is_a?(Hash)
+            if relationship_to_include.polymorphic.is_a?(Hash)
+              # static check is not possible since the serializer is defined based on the instance class
+              break
+            else
+              klass = relationship_to_include.serializer.to_s.constantize
+            end
           end
         end
       end

--- a/spec/lib/object_serializer_polymorphic_spec.rb
+++ b/spec/lib/object_serializer_polymorphic_spec.rb
@@ -81,7 +81,7 @@ describe FastJsonapi::ObjectSerializer do
       list = List.new
       list.id = 1
       list.items = [checklist_item, car]
-      expect(-> {ListSerializer.new(list, include: ["items.list"])}).not_to raise_error
+      expect { ListSerializer.new(list, include: ["items.list"]) }.not_to raise_error
     end
   end
 end

--- a/spec/lib/object_serializer_polymorphic_spec.rb
+++ b/spec/lib/object_serializer_polymorphic_spec.rb
@@ -7,10 +7,22 @@ describe FastJsonapi::ObjectSerializer do
 
   class ChecklistItem
     attr_accessor :id, :name
+
+    # fake belongs_to :list
+    attr_accessor :list_id
+    def list
+      []
+    end
   end
 
   class Car
     attr_accessor :id, :model, :year
+
+    # fake belongs_to :list
+    attr_accessor :list_id
+    def list
+      []
+    end
   end
 
   class ListSerializer
@@ -19,6 +31,21 @@ describe FastJsonapi::ObjectSerializer do
     attributes :name
     set_key_transform :dash
     has_many :items, polymorphic: true
+  end
+
+  class ChecklistItemSerializer
+    include FastJsonapi::ObjectSerializer
+    set_type :checklist_item
+    attributes :name
+    belongs_to :list
+  end
+
+  class CarSerializer
+    include FastJsonapi::ObjectSerializer
+    set_type :car
+    attributes :model
+    attributes :year
+    belongs_to :list
   end
 
   let(:car) do
@@ -46,6 +73,15 @@ describe FastJsonapi::ObjectSerializer do
       expect(record_type).to eq 'checklist-item'.to_sym
       record_type = list_hash[:data][:relationships][:items][:data][1][:type]
       expect(record_type).to eq 'car'.to_sym
+    end
+  end
+
+  context 'when serializing included polymorphic relationships' do
+    it "should not raise" do
+      list = List.new
+      list.id = 1
+      list.items = [checklist_item, car]
+      expect(-> {ListSerializer.new(list, include: ["items.list"])}).not_to raise_error
     end
   end
 end


### PR DESCRIPTION
when including `whatever.polymorphic_relation.something_else`, original code complains about `something_else` not being compatible with `whatever`