### PR TITLE
Support for polymorphic `id_method_name`

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -130,6 +130,7 @@ module FastJsonapi
         subclass.cached = cached
         subclass.set_type(subclass.reflected_record_type) if subclass.reflected_record_type
         subclass.meta_to_serialize = meta_to_serialize
+        subclass.record_id = record_id
       end
 
       def reflected_record_type
@@ -241,12 +242,15 @@ module FastJsonapi
           base_key_sym = name
           id_postfix = '_id'
         end
+        polymorphic = fetch_polymorphic_option(options)
+
         Relationship.new(
           key: options[:key] || run_key_transform(base_key),
           name: name,
           id_method_name: compute_id_method_name(
             options[:id_method_name],
             "#{base_serialization_key}#{id_postfix}".to_sym,
+            polymorphic,
             block
           ),
           record_type: options[:record_type] || run_key_transform(base_key_sym),
@@ -255,7 +259,7 @@ module FastJsonapi
           serializer: compute_serializer_name(options[:serializer] || base_key_sym),
           relationship_type: relationship_type,
           cached: options[:cached],
-          polymorphic: fetch_polymorphic_option(options),
+          polymorphic: polymorphic,
           conditional_proc: options[:if],
           transform_method: @transform_method,
           links: options[:links],
@@ -263,8 +267,8 @@ module FastJsonapi
         )
       end
 
-      def compute_id_method_name(custom_id_method_name, id_method_name_from_relationship, block)
-        if block.present?
+      def compute_id_method_name(custom_id_method_name, id_method_name_from_relationship, polymorphic, block)
+        if block.present? || polymorphic
           custom_id_method_name || :id
         else
           custom_id_method_name || id_method_name_from_relationship

--- a/lib/fast_jsonapi/relationship.rb
+++ b/lib/fast_jsonapi/relationship.rb
@@ -78,7 +78,7 @@ module FastJsonapi
     def id_hash_from_record(record, record_types)
       # memoize the record type within the record_types dictionary, then assigning to record_type:
       associated_record_type = record_types[record.class] ||= run_key_transform(record.class.name.demodulize.underscore)
-      id_hash(record.id, associated_record_type)
+      id_hash(record.public_send(id_method_name), associated_record_type)
     end
 
     def ids_hash(ids)

--- a/spec/lib/object_serializer_inheritance_spec.rb
+++ b/spec/lib/object_serializer_inheritance_spec.rb
@@ -20,7 +20,7 @@ describe FastJsonapi::ObjectSerializer do
   end
 
   class User
-    attr_accessor :id, :first_name, :last_name
+    attr_accessor :id, :first_name, :last_name, :uuid
 
     attr_accessor :address_ids, :country_id
 
@@ -39,6 +39,7 @@ describe FastJsonapi::ObjectSerializer do
   class UserSerializer
     include FastJsonapi::ObjectSerializer
     set_type :user
+    set_id :uuid
     attributes :first_name, :last_name
 
     attribute :full_name do |user, params|
@@ -125,6 +126,14 @@ describe FastJsonapi::ObjectSerializer do
       EmployeeSerializer
       expect(UserSerializer.attributes_to_serialize).not_to have_key(:location)
     end
+
+    it 'inherits the id source' do
+      e = Employee.new
+      e.id = 2
+      e.uuid = 'dfsdfsd'
+      id = EmployeeSerializer.new(e).serializable_hash[:data][:id]
+      expect(id).to eq('dfsdfsd')
+    end
   end
 
   context 'when testing inheritance of relationship' do
@@ -158,11 +167,9 @@ describe FastJsonapi::ObjectSerializer do
   end
 
   context 'when test inheritence of other attributes' do
-
     it 'inherits the tranform method' do
       EmployeeSerializer
       expect(UserSerializer.transform_method).to eq EmployeeSerializer.transform_method
     end
-
   end
 end

--- a/spec/lib/object_serializer_inheritance_spec.rb
+++ b/spec/lib/object_serializer_inheritance_spec.rb
@@ -130,9 +130,9 @@ describe FastJsonapi::ObjectSerializer do
     it 'inherits the id source' do
       e = Employee.new
       e.id = 2
-      e.uuid = 'dfsdfsd'
+      e.uuid = SecureRandom.uuid
       id = EmployeeSerializer.new(e).serializable_hash[:data][:id]
-      expect(id).to eq('dfsdfsd')
+      expect(id).to eq(e.uuid)
     end
   end
 

--- a/spec/lib/object_serializer_polymorphic_spec.rb
+++ b/spec/lib/object_serializer_polymorphic_spec.rb
@@ -51,7 +51,7 @@ describe FastJsonapi::ObjectSerializer do
     animal = Animal.new
     animal.id = 1
     animal.species = 'Mellivora capensis'
-    animal.uuid = 'sdfsdfds'
+    animal.uuid = SecureRandom.uuid
     animal
   end
 


### PR DESCRIPTION
This is a duplicate of [my PR against the Netflix project](https://github.com/Netflix/fast_jsonapi/pull/446).

For polymorphic has_many relations, instead of getting the ids in a batch, the code loops over each object to get its type and id. In Relationship#id_hash_from_record it was hardcoded to get the id by calling record.id, which overrides the id_method_name options passed into the relationship.

I tried fixing this by only changing the code in Relationship to dynamically call the id_method_name on the object, but unfortunately on has_many relationships the default value for id_method_name would be passed as if the ids would be pulled in a batch (for example groupee_ids). That default works for regular has_manys where we get the ids all at once but fails for polymorphic ones where it loops over each object.

So, fixing the problem required passing the polymorphic information to compute_id_method_name, which now defaults to id rather than id_method_name_from_relationship in the case where the relationship is polymorphic.

This also fixes a bug where the record_id is not carried over through inheritance.