### PR TITLE
Clean up some whitespace in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ end
 
 ### Compound Document
 
-Support for top-level and nested included associations through ` options[:include] `.
+Support for top-level and nested included associations through `options[:include]`.
 
 ```ruby
 options = {}
@@ -543,16 +543,16 @@ end
 
 Option | Purpose | Example
 ------------ | ------------- | -------------
-set_type | Type name of Object | ```set_type :movie ```
-key | Key of Object | ```belongs_to :owner, key: :user ```
-set_id | ID of Object | ```set_id :owner_id ``` or ```set_id { \|record, params\| params[:admin] ? record.id : "#{record.name.downcase}-#{record.id}" }```
-cache_options | Hash to enable caching and set cache length | ```cache_options enabled: true, cache_length: 12.hours, race_condition_ttl: 10.seconds```
-id_method_name | Set custom method name to get ID of an object (If block is provided for the relationship, `id_method_name` is invoked on the return value of the block instead of the resource object) | ```has_many :locations, id_method_name: :place_ids ```
-object_method_name | Set custom method name to get related objects | ```has_many :locations, object_method_name: :places ```
-record_type | Set custom Object Type for a relationship | ```belongs_to :owner, record_type: :user```
-serializer | Set custom Serializer for a relationship | ```has_many :actors, serializer: :custom_actor``` or ```has_many :actors, serializer: MyApp::Api::V1::ActorSerializer```
-polymorphic | Allows different record types for a polymorphic association | ```has_many :targets, polymorphic: true```
-polymorphic | Sets custom record types for each object class in a polymorphic association | ```has_many :targets, polymorphic: { Person => :person, Group => :group }```
+set_type | Type name of Object | `set_type :movie`
+key | Key of Object | `belongs_to :owner, key: :user`
+set_id | ID of Object | `set_id :owner_id` or `set_id { \|record, params\| params[:admin] ? record.id : "#{record.name.downcase}-#{record.id}" }`
+cache_options | Hash to enable caching and set cache length | `cache_options enabled: true, cache_length: 12.hours, race_condition_ttl: 10.seconds`
+id_method_name | Set custom method name to get ID of an object (If block is provided for the relationship, `id_method_name` is invoked on the return value of the block instead of the resource object) | `has_many :locations, id_method_name: :place_ids`
+object_method_name | Set custom method name to get related objects | `has_many :locations, object_method_name: :places`
+record_type | Set custom Object Type for a relationship | `belongs_to :owner, record_type: :user`
+serializer | Set custom Serializer for a relationship | `has_many :actors, serializer: :custom_actor` or `has_many :actors, serializer: MyApp::Api::V1::ActorSerializer`
+polymorphic | Allows different record types for a polymorphic association | `has_many :targets, polymorphic: true`
+polymorphic | Sets custom record types for each object class in a polymorphic association | `has_many :targets, polymorphic: { Person => :person, Group => :group }`
 
 ### Instrumentation
 


### PR DESCRIPTION
This is just a minor change cleaning up some unnecessary whitespace in the code examples in the README. It also replaces the 3 backticks syntax with just single ones because those aren't needed for single-line code snippets.

I've first noticed these in the original Netflix repo but that looks unmaintained unfortunately. Good job on the fork by the way, hope this can be merged back eventually or Rubygems changed to point here.