### PR TITLE
allow to set multiple meta blocks

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -227,9 +227,12 @@ module FastJsonapi
         add_relationship(relationship)
       end
 
-      def meta(&block)
-        self.meta_to_serialize ||= []
-        self.meta_to_serialize.push(block)
+      def meta(meta_name = nil, &block)
+        self.meta_to_serialize ||= {}
+
+        meta_name = meta_name ? meta_name.to_sym : :_core
+
+        self.meta_to_serialize[meta_name] = block
       end
 
       def create_relationship(base_key, relationship_type, options, block)

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -129,7 +129,7 @@ module FastJsonapi
         subclass.data_links = data_links.dup if data_links.present?
         subclass.cached = cached
         subclass.set_type(subclass.reflected_record_type) if subclass.reflected_record_type
-        subclass.meta_to_serialize = meta_to_serialize
+        subclass.meta_to_serialize = meta_to_serialize.dup if meta_to_serialize.present?
         subclass.record_id = record_id
       end
 
@@ -228,7 +228,8 @@ module FastJsonapi
       end
 
       def meta(&block)
-        self.meta_to_serialize = block
+        self.meta_to_serialize ||= []
+        self.meta_to_serialize.push(block)
       end
 
       def create_relationship(base_key, relationship_type, options, block)

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -63,13 +63,13 @@ module FastJsonapi
       end
 
       def meta_hash(record, params = {})
-        called = meta_to_serialize.map do |meta|
-          meta.call(record, params)
-        end.select(&:present?)
+        return unless meta_to_serialize
 
-        return if called.blank?
+        core_meta = meta_to_serialize[:_core] ? meta_to_serialize.delete(:_core).call(record, params) : {}
 
-        called.inject { |agg, meta| agg.deep_merge!(meta) }
+        meta_to_serialize.each_with_object(core_meta) do |(key, value), agg|
+          agg[key] = value.call(record, params)
+        end
       end
 
       def record_hash(record, fieldset, includes_list, params = {})

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -63,7 +63,13 @@ module FastJsonapi
       end
 
       def meta_hash(record, params = {})
-        meta_to_serialize.call(record, params)
+        called = meta_to_serialize.map do |meta|
+          meta.call(record, params)
+        end.select(&:present?)
+
+        return if called.blank?
+
+        called.inject { |agg, meta| agg.deep_merge!(meta) }
       end
 
       def record_hash(record, fieldset, includes_list, params = {})

--- a/spec/lib/object_serializer_class_methods_spec.rb
+++ b/spec/lib/object_serializer_class_methods_spec.rb
@@ -331,12 +331,10 @@ describe FastJsonapi::ObjectSerializer do
       expect(serializable_hash[:data][:meta]).to eq ({ years_since_release: year_since_release_calculator(movie.release_year) })
     end
 
-    context 'with a second meta call' do
+    context 'with a meta call with param' do
       before do
-        MovieSerializer.meta do
-          {
-            watch_count: 4426
-          }
+        MovieSerializer.meta :watch_count do
+          4426
         end
       end
 

--- a/spec/lib/object_serializer_class_methods_spec.rb
+++ b/spec/lib/object_serializer_class_methods_spec.rb
@@ -331,6 +331,23 @@ describe FastJsonapi::ObjectSerializer do
       expect(serializable_hash[:data][:meta]).to eq ({ years_since_release: year_since_release_calculator(movie.release_year) })
     end
 
+    context 'with a second meta call' do
+      before do
+        MovieSerializer.meta do
+          {
+            watch_count: 4426
+          }
+        end
+      end
+
+      it 'returns correct hash when serializable_hash is called' do
+        expect(serializable_hash[:data][:meta]).to eq ({
+          years_since_release: year_since_release_calculator(movie.release_year),
+          watch_count: 4426
+        })
+      end
+    end
+
     private
 
     def year_since_release_calculator(release_year)

--- a/spec/lib/object_serializer_inheritance_spec.rb
+++ b/spec/lib/object_serializer_inheritance_spec.rb
@@ -49,6 +49,12 @@ describe FastJsonapi::ObjectSerializer do
     has_many :addresses, cached: true
     belongs_to :country
     has_one :photo
+
+    meta do |object|
+      {
+        user_meta: true
+      }
+    end
   end
 
   class Photo
@@ -94,6 +100,12 @@ describe FastJsonapi::ObjectSerializer do
     attributes :compensation
 
     has_one :account
+
+    meta do
+      {
+        employee_meta: true
+      }
+    end
   end
 
   it 'sets the correct record type' do
@@ -172,4 +184,23 @@ describe FastJsonapi::ObjectSerializer do
       expect(UserSerializer.transform_method).to eq EmployeeSerializer.transform_method
     end
   end
+
+  context 'when testing inheritance of meta' do
+
+    it 'includes parent meta' do
+      subclass_meta = EmployeeSerializer.meta_to_serialize
+      superclass_meta = UserSerializer.meta_to_serialize
+      expect(subclass_meta).to include(*superclass_meta)
+    end
+
+    it 'includes child meta' do
+      expect(EmployeeSerializer.meta_to_serialize.map(&:call)).to eq([{ user_meta: true }, { employee_meta: true }])
+    end
+
+    it 'doesnt change parent class attributes' do
+      EmployeeSerializer
+      expect(UserSerializer.meta_to_serialize.map(&:call)).to eq([{ user_meta: true }])
+    end
+  end
+
 end

--- a/spec/lib/object_serializer_inheritance_spec.rb
+++ b/spec/lib/object_serializer_inheritance_spec.rb
@@ -50,10 +50,8 @@ describe FastJsonapi::ObjectSerializer do
     belongs_to :country
     has_one :photo
 
-    meta do |object|
-      {
-        user_meta: true
-      }
+    meta :user_meta do |object|
+      true
     end
   end
 
@@ -101,10 +99,8 @@ describe FastJsonapi::ObjectSerializer do
 
     has_one :account
 
-    meta do
-      {
-        employee_meta: true
-      }
+    meta :employee_meta do
+      true
     end
   end
 
@@ -186,21 +182,19 @@ describe FastJsonapi::ObjectSerializer do
   end
 
   context 'when testing inheritance of meta' do
-
     it 'includes parent meta' do
       subclass_meta = EmployeeSerializer.meta_to_serialize
       superclass_meta = UserSerializer.meta_to_serialize
-      expect(subclass_meta).to include(*superclass_meta)
+      expect(subclass_meta.keys).to include(*superclass_meta.keys)
     end
 
     it 'includes child meta' do
-      expect(EmployeeSerializer.meta_to_serialize.map(&:call)).to eq([{ user_meta: true }, { employee_meta: true }])
+      expect(EmployeeSerializer.meta_to_serialize.transform_values(&:call)).to eq(user_meta: true, employee_meta: true)
     end
 
-    it 'doesnt change parent class attributes' do
+    it 'doesnt change parent meta' do
       EmployeeSerializer
-      expect(UserSerializer.meta_to_serialize.map(&:call)).to eq([{ user_meta: true }])
+      expect(UserSerializer.meta_to_serialize.transform_values(&:call)).to eq(user_meta: true)
     end
   end
-
 end


### PR DESCRIPTION
Useful for includes and inheritance:

```rb
module SomeModule
  extend ActiveSupport::Concern

  included do
    meta do
      {
        module_meta: true
      }
    end
  end
end

class UserSerializer
  include FastJsonapi::ObjectSerializer
  include SomeModule

  meta do
    {
      user_meta: true
    }
  end
end

class EmployeeSerializer < UserSerializer
  meta do
    {
      employee_meta: true
    }
  end
end

EmployeeSerializer.new(employee).serializable_hash

{
  data: {
    [...]
    meta: {
      module_meta: true,
      user_meta: true,
      employee_meta: true
    }
  }
}
```

---

One thing to discuss is whether deep_merge or merge should be used. Only makes a difference in the exotic case of different meta blocks returning same keys though.

Otherwise I think this change makes composing serializers out of different modules and/or inheritance much more simpler, because each module or class can have meta blocks.