### PR TITLE
automatically add parent record to included record's params

### DIFF
--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -151,7 +151,10 @@ module FastJsonapi
 
               known_included_objects[code] = inc_obj
 
-              included_records << serializer.record_hash(inc_obj, fieldsets[serializer.record_type], includes_list, params)
+              params_for_included_record = params ? params.dup : {}
+              params_for_included_record[:parent] = record
+
+              included_records << serializer.record_hash(inc_obj, fieldsets[serializer.record_type], includes_list, params_for_included_record)
             end
           end
         end

--- a/spec/lib/object_serializer_attribute_param_spec.rb
+++ b/spec/lib/object_serializer_attribute_param_spec.rb
@@ -21,6 +21,16 @@ describe FastJsonapi::ObjectSerializer do
         attribute :no_param_attribute do |movie|
           "no-param-attribute"
         end
+
+        attribute :params do |movie, params|
+          params
+        end
+      end
+
+      class ActorSerializer
+        attribute :params do |actor, params|
+          params
+        end
       end
 
       User = Struct.new(:viewed)
@@ -112,6 +122,23 @@ describe FastJsonapi::ObjectSerializer do
 
           expect(no_param_attribute_values).to eq(expected_attribute_values)
         end
+      end
+    end
+
+    context "automatic parent param" do
+      let(:serializer) { MovieSerializer.new(movie, include: %i[actors]) }
+
+      it "does not add parent param to top level record" do
+        expect(hash[:data][:attributes][:params]).not_to have_key(:parent)
+      end
+
+      it "adds parent param to included record" do
+        included_actors = hash[:included].select { |object| object[:type] == :actor }
+        expect(included_actors).to be_present
+
+        expect(included_actors).to all(
+          include(attributes: hash_including(params: hash_including(parent: movie)))
+        )
       end
     end
   end


### PR DESCRIPTION
```rb
class ThingSerializer
  belogs_to :user
end

class UserSerializer
  attribute :first_name do |object, params|
    # `params[:parent] == thing` if this serializer was called as
    # part of ThingSerializer, `thing` is the parent record
  end
end
```

---

This makes it possible to change behavior of serializers depending on whether they are called through an association or not. I use it for things like expensive computations that I don't want to do if the record is just included as an association.

I'm not sure if adding a it to `params` is the way to go or whether there should be another parameter to the blocks (e.g. `attribute :first_name { |object, params, parent| ... }`). This would make sure it never overwrites a user defined `:parent` (if there is any) but makes the block signature more complicated.

Or maybe you have another idea how to detect if the serialized record is included as an association?