### PR TITLE
Use a configurable namespace when generating caching key

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -125,6 +125,7 @@ module FastJsonapi
         subclass.uncachable_relationships_to_serialize = uncachable_relationships_to_serialize.dup if uncachable_relationships_to_serialize.present?
         subclass.transform_method = transform_method
         subclass.cache_length = cache_length
+        subclass.cache_namespace = cache_namespace
         subclass.race_condition_ttl = race_condition_ttl
         subclass.data_links = data_links.dup if data_links.present?
         subclass.cached = cached
@@ -178,6 +179,7 @@ module FastJsonapi
       def cache_options(cache_options)
         self.cached = cache_options[:enabled] || false
         self.cache_length = cache_options[:cache_length] || 5.minutes
+        self.cache_namespace = cache_options[:cache_namespace]
         self.race_condition_ttl = cache_options[:race_condition_ttl] || 5.seconds
       end
 

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -19,6 +19,7 @@ module FastJsonapi
                       :record_type,
                       :record_id,
                       :cache_length,
+                      :cache_namespace,
                       :race_condition_ttl,
                       :cached,
                       :data_links,
@@ -68,7 +69,7 @@ module FastJsonapi
 
       def record_hash(record, fieldset, includes_list, params = {})
         if cached
-          record_hash = Rails.cache.fetch(record.cache_key, expires_in: cache_length, race_condition_ttl: race_condition_ttl) do
+          record_hash = Rails.cache.fetch("#{cache_namespace}#{record.cache_key}", expires_in: cache_length, race_condition_ttl: race_condition_ttl) do
             temp_hash = id_hash(id_from_record(record, params), record_type, true)
             temp_hash[:attributes] = attributes_hash(record, fieldset, params) if attributes_to_serialize.present?
             temp_hash[:relationships] = {}


### PR DESCRIPTION
I don't give up ;-)

## What is the current behavior?

The library uses `record.cache_key` as the cache key, without any namespace, e.g. `Rails.cache.fetch(record.cache_key, ...)`. This is very generic and could be used by some other library or the Rails app already. It should be possible to specify a different namespace.

## What is the new behavior?

It will now prefix the cache key with a namespace. It can be configured with `cache_options cache_namespace: ...` and will prefix the cache key then.

```rb
cache_options cache_namepspace: 'some_namespace'

=> Rails.cache.fetch("some_namespace#{record.cache_key}", ...)
```

## Questions

- Is this a good addition?
- Should there be a default namespace, or should it stay `nil` like now so it does not change current cache keys?
- Should there be any tests?

## Checklist

Please make sure the following requirements are complete:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features) --> will be done if this has a change to be merged
- [ ] All automated checks pass (CI/CD)
