### PR TITLE
Support cache versioning

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -125,6 +125,7 @@ module FastJsonapi
         subclass.uncachable_relationships_to_serialize = uncachable_relationships_to_serialize.dup if uncachable_relationships_to_serialize.present?
         subclass.transform_method = transform_method
         subclass.cache_length = cache_length
+        subclass.cache_versioning = cache_versioning
         subclass.race_condition_ttl = race_condition_ttl
         subclass.data_links = data_links.dup if data_links.present?
         subclass.cached = cached
@@ -178,6 +179,7 @@ module FastJsonapi
       def cache_options(cache_options)
         self.cached = cache_options[:enabled] || false
         self.cache_length = cache_options[:cache_length] || 5.minutes
+        self.cache_versioning = cache_options[:cache_versioning] || false
         self.race_condition_ttl = cache_options[:race_condition_ttl] || 5.seconds
       end
 

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -19,6 +19,7 @@ module FastJsonapi
                       :record_type,
                       :record_id,
                       :cache_length,
+                      :cache_versioning,
                       :race_condition_ttl,
                       :cached,
                       :data_links,
@@ -68,7 +69,7 @@ module FastJsonapi
 
       def record_hash(record, fieldset, includes_list, params = {})
         if cached
-          record_hash = Rails.cache.fetch(record.cache_key, expires_in: cache_length, race_condition_ttl: race_condition_ttl) do
+          record_hash = Rails.cache.fetch(record.cache_key, expires_in: cache_length, race_condition_ttl: race_condition_ttl, version: cache_versioning ? record.cache_version : nil) do
             temp_hash = id_hash(id_from_record(record, params), record_type, true)
             temp_hash[:attributes] = attributes_hash(record, fieldset, params) if attributes_to_serialize.present?
             temp_hash[:relationships] = {}

--- a/spec/shared/contexts/movie_context.rb
+++ b/spec/shared/contexts/movie_context.rb
@@ -10,7 +10,8 @@ RSpec.shared_context 'movie class' do
                     :director,
                     :actor_ids,
                     :owner_id,
-                    :movie_type_id
+                    :movie_type_id,
+                    :cache_version
 
       def actors
         actor_ids.map.with_index do |id, i|
@@ -217,6 +218,17 @@ RSpec.shared_context 'movie class' do
       belongs_to :movie_type
 
       cache_options enabled: true
+    end
+
+    class CachingMovieSerializerWithCacheVersioning
+      include FastJsonapi::ObjectSerializer
+      set_type :movie
+      attributes :name, :release_year
+      has_many :actors
+      belongs_to :owner, record_type: :user
+      belongs_to :movie_type
+
+      cache_options enabled: true, cache_versioning: true
     end
 
     class CachingMovieWithHasManySerializer


### PR DESCRIPTION
## What is the current behavior?

There is no way to use a cache version when deriving the cache key of a record. It currenctly simply uses `record.cache_key`. If [cache versioning](https://github.com/rails/rails/pull/29092) is enabled, the cache key will never change, even if the record got updated.

## What is the new behavior?

Cache versioning can be enabled with:

```rb
cache_options cache_versioning: true
```

It will automatically pass `version: record.cache_version` when fetching the cache.

## Questions

- Should the default automatically be inferred by checking `Rails.application.config.active_record.cache_versioning`?
- Is it OK to pass `version: nil` to `Rails.cache.fetch` if cache versioning is disabled or should the call omit the `version:` in that case? (maybe it could brake older Rails apps?)

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features) --> will be done if this has a chance to be merged
- [ ] All automated checks pass (CI/CD)
