### PR TITLE
refactor caching options and require own cache instance

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -125,7 +125,6 @@ module FastJsonapi
         subclass.uncachable_relationships_to_serialize = uncachable_relationships_to_serialize.dup if uncachable_relationships_to_serialize.present?
         subclass.transform_method = transform_method
         subclass.data_links = data_links.dup if data_links.present?
-        subclass.cached = cached
         subclass.cache_store_instance = cache_store_instance
         subclass.set_type(subclass.reflected_record_type) if subclass.reflected_record_type
         subclass.meta_to_serialize = meta_to_serialize
@@ -174,9 +173,13 @@ module FastJsonapi
         self.record_id = block || id_name
       end
 
-      def cache_store(store)
-        self.cached = store.present?
-        self.cache_store_instance = store
+      def cache_options(cache_options)
+        deprecated_options = %i[enabled cache_length race_condition_ttl]
+        if deprecated_options.any? { |key| cache_options.key?(key) }
+          raise ArgumentError, "#{deprecated_options.to_sentence} are deprecated cache options and have no effect anymore. Please specify your own cache with `store: store_instance` instead."
+        end
+
+        self.cache_store_instance = cache_options[:store]
       end
 
       def attributes(*attributes_list, &block)

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -124,10 +124,9 @@ module FastJsonapi
         subclass.cachable_relationships_to_serialize = cachable_relationships_to_serialize.dup if cachable_relationships_to_serialize.present?
         subclass.uncachable_relationships_to_serialize = uncachable_relationships_to_serialize.dup if uncachable_relationships_to_serialize.present?
         subclass.transform_method = transform_method
-        subclass.cache_length = cache_length
-        subclass.race_condition_ttl = race_condition_ttl
         subclass.data_links = data_links.dup if data_links.present?
         subclass.cached = cached
+        subclass.cache_store_instance = cache_store_instance
         subclass.set_type(subclass.reflected_record_type) if subclass.reflected_record_type
         subclass.meta_to_serialize = meta_to_serialize
         subclass.record_id = record_id
@@ -175,10 +174,9 @@ module FastJsonapi
         self.record_id = block || id_name
       end
 
-      def cache_options(cache_options)
-        self.cached = cache_options[:enabled] || false
-        self.cache_length = cache_options[:cache_length] || 5.minutes
-        self.race_condition_ttl = cache_options[:race_condition_ttl] || 5.seconds
+      def cache_store(store)
+        self.cached = store.present?
+        self.cache_store_instance = store
       end
 
       def attributes(*attributes_list, &block)

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -190,10 +190,10 @@ module FastJsonapi
 
       # FIXME: remove this method once deprecated cache_options are not supported anymore
       def deprecated_cache_options(cache_options)
-        warn('DEPRECATION WARNING: `store:` is a required cache option, we will default to `Rails.cache` for now.')
+        warn('DEPRECATION WARNING: `store:` is a required cache option, we will default to `Rails.cache` for now. See https://github.com/fast-jsonapi/fast_jsonapi#caching for more information.')
 
         %i[enabled cache_length].select { |key| cache_options.key?(key) }.each do |key|
-          warn("DEPRECATION WARNING: `#{key}` is a deprecated cache option and will have no effect soon. See <link to docs>")
+          warn("DEPRECATION WARNING: `#{key}` is a deprecated cache option and will have no effect soon. See https://github.com/fast-jsonapi/fast_jsonapi#caching for more information.")
         end
 
         self.cache_store_instance = cache_options[:enabled] ? Rails.cache : nil
@@ -202,7 +202,6 @@ module FastJsonapi
           race_condition_ttl: cache_options[:race_condition_ttl] || 5.seconds
         }
       end
-
 
       def attributes(*attributes_list, &block)
         attributes_list = attributes_list.first if attributes_list.first.class.is_a?(Array)

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -126,7 +126,7 @@ module FastJsonapi
         subclass.transform_method = transform_method
         subclass.data_links = data_links.dup if data_links.present?
         subclass.cache_store_instance = cache_store_instance
-        subclass.cache_store_options = cache_store_options.dup if cache_store_options.present?
+        subclass.cache_store_options = cache_store_options
         subclass.set_type(subclass.reflected_record_type) if subclass.reflected_record_type
         subclass.meta_to_serialize = meta_to_serialize
         subclass.record_id = record_id

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -126,6 +126,7 @@ module FastJsonapi
         subclass.transform_method = transform_method
         subclass.data_links = data_links.dup if data_links.present?
         subclass.cache_store_instance = cache_store_instance
+        subclass.cache_store_options = cache_store_options.dup if cache_store_options.present?
         subclass.set_type(subclass.reflected_record_type) if subclass.reflected_record_type
         subclass.meta_to_serialize = meta_to_serialize
         subclass.record_id = record_id
@@ -174,12 +175,23 @@ module FastJsonapi
       end
 
       def cache_options(cache_options)
-        deprecated_options = %i[enabled cache_length race_condition_ttl]
-        if deprecated_options.any? { |key| cache_options.key?(key) }
-          raise ArgumentError, "#{deprecated_options.to_sentence} are deprecated cache options and have no effect anymore. Please specify your own cache with `store: store_instance` instead."
+        cache_options = cache_options.dup
+
+        if cache_options.key?(:store)
+          self.cache_store_instance = cache_options.delete(:store)
+        elsif !cache_store_instance
+          warn('DEPRECATION WARNING: `store:` is required, we will default to `Rails.cache`.')
+          self.cache_store_instance =  Rails.cache
         end
 
-        self.cache_store_instance = cache_options[:store]
+        %i[enabled cache_length].each do |key|
+          if cache_options.key?(key)
+            warn("DEPRECATION WARNING: `#{key}:` is a deprecated cache option and has no effect anymore.")
+            cache_options.delete(key)
+          end
+        end
+
+        self.cache_store_options = (cache_store_options || {}).merge(cache_options)
       end
 
       def attributes(*attributes_list, &block)

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -175,23 +175,18 @@ module FastJsonapi
       end
 
       def cache_options(cache_options)
-        cache_options = cache_options.dup
-
         if cache_options.key?(:store)
-          self.cache_store_instance = cache_options.delete(:store)
-        elsif !cache_store_instance
+          self.cache_store_instance = cache_options[:store]
+        else
           warn('DEPRECATION WARNING: `store:` is required, we will default to `Rails.cache`.')
           self.cache_store_instance =  Rails.cache
         end
 
         %i[enabled cache_length].each do |key|
-          if cache_options.key?(key)
-            warn("DEPRECATION WARNING: `#{key}:` is a deprecated cache option and has no effect anymore.")
-            cache_options.delete(key)
-          end
+          warn("DEPRECATION WARNING: `#{key}:` is a deprecated cache option and has no effect anymore.") if cache_options.key?(key)
         end
 
-        self.cache_store_options = (cache_store_options || {}).merge(cache_options)
+        self.cache_store_options = cache_options.except(:store, :enabled, :cache_length)
       end
 
       def attributes(*attributes_list, &block)

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -18,9 +18,8 @@ module FastJsonapi
                       :transform_method,
                       :record_type,
                       :record_id,
-                      :cache_length,
-                      :race_condition_ttl,
                       :cached,
+                      :cache_store_instance,
                       :data_links,
                       :meta_to_serialize
       end
@@ -68,7 +67,7 @@ module FastJsonapi
 
       def record_hash(record, fieldset, includes_list, params = {})
         if cached
-          record_hash = Rails.cache.fetch(record.cache_key, expires_in: cache_length, race_condition_ttl: race_condition_ttl) do
+          record_hash = cache_store_instance.fetch(record) do
             temp_hash = id_hash(id_from_record(record, params), record_type, true)
             temp_hash[:attributes] = attributes_hash(record, fieldset, params) if attributes_to_serialize.present?
             temp_hash[:relationships] = {}

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -19,6 +19,7 @@ module FastJsonapi
                       :record_type,
                       :record_id,
                       :cache_store_instance,
+                      :cache_store_options,
                       :data_links,
                       :meta_to_serialize
       end
@@ -66,7 +67,7 @@ module FastJsonapi
 
       def record_hash(record, fieldset, includes_list, params = {})
         if cache_store_instance
-          record_hash = cache_store_instance.fetch(record) do
+          record_hash = cache_store_instance.fetch(record, *cache_store_options) do
             temp_hash = id_hash(id_from_record(record, params), record_type, true)
             temp_hash[:attributes] = attributes_hash(record, fieldset, params) if attributes_to_serialize.present?
             temp_hash[:relationships] = {}

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -67,7 +67,7 @@ module FastJsonapi
 
       def record_hash(record, fieldset, includes_list, params = {})
         if cache_store_instance
-          record_hash = cache_store_instance.fetch(record, *cache_store_options) do
+          record_hash = cache_store_instance.fetch(record, **cache_store_options) do
             temp_hash = id_hash(id_from_record(record, params), record_type, true)
             temp_hash[:attributes] = attributes_hash(record, fieldset, params) if attributes_to_serialize.present?
             temp_hash[:relationships] = {}

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -18,7 +18,6 @@ module FastJsonapi
                       :transform_method,
                       :record_type,
                       :record_id,
-                      :cached,
                       :cache_store_instance,
                       :data_links,
                       :meta_to_serialize
@@ -66,7 +65,7 @@ module FastJsonapi
       end
 
       def record_hash(record, fieldset, includes_list, params = {})
-        if cached
+        if cache_store_instance
           record_hash = cache_store_instance.fetch(record) do
             temp_hash = id_hash(id_from_record(record, params), record_type, true)
             temp_hash[:attributes] = attributes_hash(record, fieldset, params) if attributes_to_serialize.present?

--- a/spec/lib/object_serializer_caching_spec.rb
+++ b/spec/lib/object_serializer_caching_spec.rb
@@ -64,4 +64,44 @@ describe FastJsonapi::ObjectSerializer do
       expect(serializable_hash[:data][:relationships][:actors][:data].length).to eq previous_actors.length
     end
   end
+
+  # FIXME: remove this if block once deprecated cache_options are not supported anymore
+  context 'when using deprecated cache options' do
+    let(:deprecated_caching_movie_serializer_class) do
+      rails = OpenStruct.new
+      rails.cache = ActiveSupport::Cache::MemoryStore.new
+      stub_const('Rails', rails)
+
+      Class.new do
+        def self.name
+          'DeprecatedCachingMovieSerializer'
+        end
+
+        include FastJsonapi::ObjectSerializer
+        set_type :movie
+        attributes :name, :release_year
+        has_many :actors
+        belongs_to :owner, record_type: :user
+        belongs_to :movie_type
+
+        cache_options enabled: true
+      end
+    end
+
+    it 'uses cached values for the record' do
+      previous_name = movie.name
+      previous_actors = movie.actors
+      deprecated_caching_movie_serializer_class.new(movie).serializable_hash
+
+      movie.name = 'should not match'
+      allow(movie).to receive(:actor_ids).and_return([99])
+
+      expect(previous_name).not_to eq(movie.name)
+      expect(previous_actors).not_to eq(movie.actors)
+      serializable_hash = deprecated_caching_movie_serializer_class.new(movie).serializable_hash
+
+      expect(serializable_hash[:data][:attributes][:name]).to eq(previous_name)
+      expect(serializable_hash[:data][:relationships][:actors][:data].length).to eq movie.actors.length
+    end
+  end
 end

--- a/spec/lib/object_serializer_caching_spec.rb
+++ b/spec/lib/object_serializer_caching_spec.rb
@@ -4,12 +4,6 @@ describe FastJsonapi::ObjectSerializer do
   include_context 'movie class'
 
   context 'when caching has_many' do
-    before(:each) do
-      rails = OpenStruct.new
-      rails.cache = ActiveSupport::Cache::MemoryStore.new
-      stub_const('Rails', rails)
-    end
-
     it 'returns correct hash when serializable_hash is called' do
       options = {}
       options[:meta] = { total: 2 }

--- a/spec/shared/contexts/movie_context.rb
+++ b/spec/shared/contexts/movie_context.rb
@@ -216,7 +216,7 @@ RSpec.shared_context 'movie class' do
       belongs_to :owner, record_type: :user
       belongs_to :movie_type
 
-      cache_options enabled: true
+      cache_store ActiveSupport::Cache::MemoryStore.new
     end
 
     class CachingMovieWithHasManySerializer
@@ -227,7 +227,7 @@ RSpec.shared_context 'movie class' do
       belongs_to :owner, record_type: :user
       belongs_to :movie_type
 
-      cache_options enabled: true
+      cache_store ActiveSupport::Cache::MemoryStore.new
     end
 
     class ActorSerializer

--- a/spec/shared/contexts/movie_context.rb
+++ b/spec/shared/contexts/movie_context.rb
@@ -216,7 +216,7 @@ RSpec.shared_context 'movie class' do
       belongs_to :owner, record_type: :user
       belongs_to :movie_type
 
-      cache_store ActiveSupport::Cache::MemoryStore.new
+      cache_options store: ActiveSupport::Cache::MemoryStore.new
     end
 
     class CachingMovieWithHasManySerializer
@@ -227,7 +227,7 @@ RSpec.shared_context 'movie class' do
       belongs_to :owner, record_type: :user
       belongs_to :movie_type
 
-      cache_store ActiveSupport::Cache::MemoryStore.new
+      cache_options store: ActiveSupport::Cache::MemoryStore.new
     end
 
     class ActorSerializer

--- a/spec/shared/contexts/movie_context.rb
+++ b/spec/shared/contexts/movie_context.rb
@@ -216,7 +216,7 @@ RSpec.shared_context 'movie class' do
       belongs_to :owner, record_type: :user
       belongs_to :movie_type
 
-      cache_options store: ActiveSupport::Cache::MemoryStore.new
+      cache_options store: ActiveSupport::Cache::MemoryStore.new, expires_in: 5.minutes
     end
 
     class CachingMovieWithHasManySerializer
@@ -227,7 +227,7 @@ RSpec.shared_context 'movie class' do
       belongs_to :owner, record_type: :user
       belongs_to :movie_type
 
-      cache_options store: ActiveSupport::Cache::MemoryStore.new
+      cache_options store: ActiveSupport::Cache::MemoryStore.new, namespace: 'fast-jsonapi'
     end
 
     class ActorSerializer


### PR DESCRIPTION
To enable caching, you must pass a cache store instance:

```rb
class UserSerializer
  include FastJsonApi::ObjectSerializer

  # enable caching
  cache_store ActiveSupport::Cache::MemoryStore.new
end
```

To disable it, simply pass a falsy value:

```rb
class AdminUserSerializer < UserSerializer
  # disable caching
  cache_store false
end
```

Set race condition ttl and namespace:

```rb
class UserSerializer
  include FastJsonApi::ObjectSerializer

  # setting all cache options is now possible
  cache_store ActiveSupport::Cache::MemoryStore.new(
    race_condition_ttl: 20.seconds, namespace: 'my_caching_namespace'
  )
end
```

- Very explicit where cache is stored
- No `Rails.cache` automagic with possible colliding keys
- Rails 5.2+ cache versioning support by using a cache that supports it
- Implicit namespace support (by cache instance, e.g.
  `ActiveSupport::Cache::MemoryStore.new(namespace: 'jast_jsonapi')`
- All cache options can be set directly, no need to for fast jsonapi to handle them

refs #51

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
