### PR TITLE
Make `meta` work similar to other methods like `attribute`, `links, `has_many`, ...

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -133,7 +133,8 @@ module FastJsonapi
         subclass.cache_store_instance = cache_store_instance
         subclass.cache_store_options = cache_store_options
         subclass.set_type(subclass.reflected_record_type) if subclass.reflected_record_type
-        subclass.meta_to_serialize = meta_to_serialize
+        subclass.meta_core_to_serialize = meta_core_to_serialize
+        subclass.meta_to_serialize = meta_to_serialize.dup if meta_to_serialize.present?
         subclass.record_id = record_id
       end
 
@@ -208,10 +209,9 @@ module FastJsonapi
         }
       end
 
-      def attributes(*attributes_list, &block)
+      def add_attributes_to(attributes_list, block, target)
         attributes_list = attributes_list.first if attributes_list.first.class.is_a?(Array)
         options = attributes_list.last.is_a?(Hash) ? attributes_list.pop : {}
-        self.attributes_to_serialize = {} if self.attributes_to_serialize.nil?
 
         # to support calling `attribute` with a lambda, e.g `attribute :key, ->(object) { ... }`
         block = attributes_list.pop if attributes_list.last.is_a?(Proc)
@@ -219,12 +219,18 @@ module FastJsonapi
         attributes_list.each do |attr_name|
           method_name = attr_name
           key = run_key_transform(method_name)
-          attributes_to_serialize[key] = Attribute.new(
+          target[key] = Attribute.new(
             key: key,
             method: block || method_name,
             options: options
           )
         end
+      end
+
+      def attributes(*attributes_list, &block)
+        self.attributes_to_serialize = {} if self.attributes_to_serialize.nil?
+
+        add_attributes_to(attributes_list, block, attributes_to_serialize)
       end
 
       alias_method :attribute, :attributes
@@ -257,8 +263,19 @@ module FastJsonapi
         add_relationship(relationship)
       end
 
-      def meta(meta_name = nil, &block)
-        self.meta_to_serialize = block || meta_name
+      def meta(*meta_list, &block)
+        # to support calling `meta` with only a lambda, e.g `meta ->(object) { ... }`
+        block = meta_list.pop if meta_list.last.is_a?(Proc)
+
+        # for backwards compatibility when `meta` is called without a list
+        if meta_list.blank?
+          self.meta_core_to_serialize = block
+          return
+        end
+
+        self.meta_to_serialize = {} if self.meta_to_serialize.nil?
+
+        add_attributes_to(meta_list, block, meta_to_serialize)
       end
 
       def create_relationship(base_key, relationship_type, options, block)

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -20,6 +20,7 @@ module FastJsonapi
                       :cache_store_instance,
                       :cache_store_options,
                       :data_links,
+                      :meta_core_to_serialize,
                       :meta_to_serialize
       end
     end
@@ -61,7 +62,16 @@ module FastJsonapi
       end
 
       def meta_hash(record, params = {})
-        FastJsonapi.call_proc(meta_to_serialize, record, params)
+        return if !meta_core_to_serialize && !meta_to_serialize
+
+        base = meta_core_to_serialize ? FastJsonapi.call_proc(meta_core_to_serialize, record, params) : {}
+        return base unless meta_to_serialize
+
+        meta_to_serialize.each do |(_k, attribute)|
+          attribute.serialize(record, params, base)
+        end
+
+        base
       end
 
       def record_hash(record, fieldset, includes_list, params = {})
@@ -75,14 +85,20 @@ module FastJsonapi
             temp_hash
           end
           record_hash[:relationships] = record_hash[:relationships].merge(relationships_hash(record, uncachable_relationships_to_serialize, fieldset, includes_list, params)) if uncachable_relationships_to_serialize.present?
-          record_hash[:meta] = meta_hash(record, params) if meta_to_serialize.present?
+
+          cur_meta = meta_hash(record, params)
+          record_hash[:meta] = cur_meta if cur_meta.present?
+
           record_hash
         else
           record_hash = id_hash(id_from_record(record, params), record_type, true)
           record_hash[:attributes] = attributes_hash(record, fieldset, params) if attributes_to_serialize.present?
           record_hash[:relationships] = relationships_hash(record, nil, fieldset, includes_list, params) if relationships_to_serialize.present?
           record_hash[:links] = links_hash(record, params) if data_links.present?
-          record_hash[:meta] = meta_hash(record, params) if meta_to_serialize.present?
+
+          cur_meta = meta_hash(record, params)
+          record_hash[:meta] = cur_meta if cur_meta.present?
+
           record_hash
         end
       end

--- a/spec/lib/object_serializer_inheritance_spec.rb
+++ b/spec/lib/object_serializer_inheritance_spec.rb
@@ -49,6 +49,10 @@ describe FastJsonapi::ObjectSerializer do
     has_many :addresses, cached: true
     belongs_to :country
     has_one :photo
+
+    meta :user_meta do |object|
+      true
+    end
   end
 
   class Address
@@ -108,6 +112,10 @@ describe FastJsonapi::ObjectSerializer do
     attributes :compensation
 
     has_one :account, serializer: EmployeeAccountSerializer
+
+    meta :employee_meta do
+      true
+    end
   end
 
   it 'sets the correct record type' do
@@ -184,6 +192,23 @@ describe FastJsonapi::ObjectSerializer do
     it 'inherits the tranform method' do
       EmployeeSerializer
       expect(UserSerializer.transform_method).to eq EmployeeSerializer.transform_method
+    end
+  end
+
+  context 'when testing inheritance of meta' do
+    it 'includes parent meta' do
+      subclass_meta = EmployeeSerializer.meta_to_serialize
+      superclass_meta = UserSerializer.meta_to_serialize
+      expect(subclass_meta).to include(superclass_meta)
+    end
+
+    it 'includes child meta' do
+      expect(EmployeeSerializer.meta_to_serialize[:employee_meta].method.call).to eq(true)
+    end
+
+    it 'doesnt change parent meta' do
+      EmployeeSerializer
+      expect(UserSerializer.meta_to_serialize).not_to have_key(:employee_meta)
     end
   end
 end


### PR DESCRIPTION
Refs #36, but to have a clean start/discussion I opened this one (because I feel this proposal got lost there in the end). Since there is code already I open this as a MR, feel free to open an issue if the idea should be discussed there (and this here is only about code).

---

All in all it makes `meta` behave exactly the same a `attribute`,
because in the end they both do the same thing: output a hash based on
the record and params.

Key changes, now possible with `meta` like with `attribute` already:

- `meta` accepts a parameter now. E.g. to output `meta: { some: :key }`,
  it is possible to do `meta :some { :key }` now.
- It can be conditional with `if: proc {}`: `meta :some, if: proc { ... }`
- Multiple `meta` calls are possible now, each adding a key to the meta
  hash
- Without a block it calls record's attribute with that name:
  `meta :attr` will call `record.attr`. This might not be very useful for
  `meta` but to keep the code the same it works like this and shouldn't
  hurt.

To stay backwards compatible it is still possible to call `meta` with
only a block and it will do the same as it did before. Maybe this
should be deprecated in the long term.

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
