### PR TITLE
Fix conditional procedures with lambdas

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -232,8 +232,8 @@ module FastJsonapi
         add_relationship(relationship)
       end
 
-      def meta(&block)
-        self.meta_to_serialize = block
+      def meta(meta_name = nil, &block)
+        self.meta_to_serialize = block || meta_name
       end
 
       def create_relationship(base_key, relationship_type, options, block)

--- a/lib/fast_jsonapi/relationship.rb
+++ b/lib/fast_jsonapi/relationship.rb
@@ -57,7 +57,7 @@ module FastJsonapi
 
     def include_relationship?(record, serialization_params)
       if conditional_proc.present?
-        conditional_proc.call(record, serialization_params)
+        FastJsonapi.call_proc(conditional_proc, record, serialization_params)
       else
         true
       end
@@ -73,7 +73,7 @@ module FastJsonapi
         serializer_for_name(name)
 
       elsif serializer.is_a?(Proc)
-        serializer.arity.abs == 1 ? serializer.call(record) : serializer.call(record, serialization_params)
+        FastJsonapi.call_proc(serializer, record, serialization_params)
 
       elsif object_block
         serializer_for_name(record.class.name)

--- a/lib/fast_jsonapi/scalar.rb
+++ b/lib/fast_jsonapi/scalar.rb
@@ -11,7 +11,7 @@ module FastJsonapi
     def serialize(record, serialization_params, output_hash)
       if conditionally_allowed?(record, serialization_params)
         output_hash[key] = if method.is_a?(Proc)
-          method.arity.abs == 1 ? method.call(record) : method.call(record, serialization_params)
+          FastJsonapi.call_proc(method, record, serialization_params)
         else
           record.public_send(method)
         end
@@ -20,7 +20,7 @@ module FastJsonapi
 
     def conditionally_allowed?(record, serialization_params)
       if conditional_proc.present?
-        conditional_proc.call(record, serialization_params)
+        FastJsonapi.call_proc(conditional_proc, record, serialization_params)
       else
         true
       end

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -62,7 +62,7 @@ module FastJsonapi
       end
 
       def meta_hash(record, params = {})
-        meta_to_serialize.call(record, params)
+        FastJsonapi.call_proc(meta_to_serialize, record, params)
       end
 
       def record_hash(record, fieldset, includes_list, params = {})
@@ -89,7 +89,7 @@ module FastJsonapi
       end
 
       def id_from_record(record, params)
-        return record_id.call(record, params) if record_id.is_a?(Proc)
+        return FastJsonapi.call_proc(record_id, record, params) if record_id.is_a?(Proc)
         return record.send(record_id) if record_id
         raise MandatoryField, 'id is a mandatory field in the jsonapi spec' unless record.respond_to?(:id)
         record.id

--- a/spec/lib/object_serializer_spec.rb
+++ b/spec/lib/object_serializer_spec.rb
@@ -451,6 +451,22 @@ describe FastJsonapi::ObjectSerializer do
     end
   end
 
+  context 'when optional attributes are determined by record data with a lambda' do
+    it 'returns optional attribute when attribute is included' do
+      movie.release_year = 2001
+      json = MovieOptionalRecordDataWithLambdaSerializer.new(movie).serialized_json
+      serializable_hash = JSON.parse(json)
+      expect(serializable_hash['data']['attributes']['release_year']).to eq movie.release_year
+    end
+
+    it "doesn't return optional attribute when attribute is not included" do
+      movie.release_year = 1970
+      json = MovieOptionalRecordDataWithLambdaSerializer.new(movie).serialized_json
+      serializable_hash = JSON.parse(json)
+      expect(serializable_hash['data']['attributes'].has_key?('release_year')).to be_falsey
+    end
+  end
+
   context 'when optional attributes are determined by params data' do
     it 'returns optional attribute when attribute is included' do
       movie.director = 'steven spielberg'
@@ -477,6 +493,38 @@ describe FastJsonapi::ObjectSerializer do
     context "when relationship is not included" do
       let(:json) {
         MovieOptionalRelationshipSerializer.new(movie, options).serialized_json
+      }
+      let(:options) {
+        {}
+      }
+      let(:serializable_hash) {
+        JSON.parse(json)
+      }
+
+      it "doesn't return optional relationship" do
+        movie.actor_ids = []
+        expect(serializable_hash['data']['relationships'].has_key?('actors')).to be_falsey
+      end
+
+      it "doesn't include optional relationship" do
+        movie.actor_ids = []
+        options[:include] = [:actors]
+        expect(serializable_hash['included']).to be_blank
+      end
+
+    end
+  end
+
+  context 'when optional relationships are determined by record data with a lambda' do
+    it 'returns optional relationship when relationship is included' do
+      json = MovieOptionalRelationshipWithLambdaSerializer.new(movie).serialized_json
+      serializable_hash = JSON.parse(json)
+      expect(serializable_hash['data']['relationships'].has_key?('actors')).to be_truthy
+    end
+
+    context "when relationship is not included" do
+      let(:json) {
+        MovieOptionalRelationshipWithLambdaSerializer.new(movie, options).serialized_json
       }
       let(:options) {
         {}

--- a/spec/shared/contexts/movie_context.rb
+++ b/spec/shared/contexts/movie_context.rb
@@ -203,6 +203,12 @@ RSpec.shared_context 'movie class' do
       end
     end
 
+    class OptionalDownloadableMovieWithLambdaSerializer < MovieSerializer
+      link(:download, if: ->(record) { record.release_year >= 2000 }) do |movie|
+        "/download/#{movie.id}"
+      end
+    end
+
     class MovieWithoutIdStructSerializer
       include FastJsonapi::ObjectSerializer
       attributes :name, :release_year
@@ -319,6 +325,13 @@ RSpec.shared_context 'movie class' do
       attribute :release_year, if: Proc.new { |record| record.release_year >= 2000 }
     end
 
+    class MovieOptionalRecordDataWithLambdaSerializer
+      include FastJsonapi::ObjectSerializer
+      set_type :movie
+      attributes :name
+      attribute :release_year, if: ->(record) { record.release_year >= 2000 }
+    end
+
     class MovieOptionalParamsDataSerializer
       include FastJsonapi::ObjectSerializer
       set_type :movie
@@ -331,6 +344,13 @@ RSpec.shared_context 'movie class' do
       set_type :movie
       attributes :name
       has_many :actors, if: Proc.new { |record| record.actors.any? }
+    end
+
+    class MovieOptionalRelationshipWithLambdaSerializer
+      include FastJsonapi::ObjectSerializer
+      set_type :movie
+      attributes :name
+      has_many :actors, if: ->(record) { record.actors.any? }
     end
 
     class MovieOptionalRelationshipWithParamsSerializer
@@ -392,6 +412,7 @@ RSpec.shared_context 'movie class' do
       GenreMovieSerializer
       HorrorMovieSerializer
       OptionalDownloadableMovieSerializer
+      OptionalDownloadableMovieWithLambdaSerializer
       Movie
       MovieSerializer
       Actor


### PR DESCRIPTION
## What is the current behavior?

Conditional procedures for scalars and relationships don't work when used with lambdas, for example:

```ruby
class MovieSerializer
  include FastJsonapi::ObjectSerializer

  attribute :release_year, if: ->(record) { record.release_year >= 2000 }
  has_many :actors, if: ->(record) { record.actors.any? }
end
```

These currently throw an error: `ArgumentError: wrong number of arguments (given 2, expected 1)`.

This is very similar to the `&:proc` shorthand issue I've been working on at #58.

## What is the new behavior?

This change fixes the behavior to be able to use lambdas as well as `Proc`s with either one or two parameters.

This also includes the arity check for lambdas, which could be extracted to a common place.

## Checklist

Please make sure the following requirements are complete:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [X] All automated checks pass (CI/CD)
