### PR TITLE
Improvements to `include`

### DIFF
--- a/lib/fast_jsonapi/errors.rb
+++ b/lib/fast_jsonapi/errors.rb
@@ -1,0 +1,6 @@
+module FastJsonapi
+
+  class InvalidIncludeError < ArgumentError
+  end
+
+end

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -2,6 +2,7 @@
 
 require 'active_support/concern'
 require 'fast_jsonapi/multi_to_json'
+require 'fast_jsonapi/errors'
 
 module FastJsonapi
   MandatoryField = Class.new(StandardError)
@@ -107,7 +108,7 @@ module FastJsonapi
 
         includes_list.each_with_object([]) do |(item, subitems), included_records|
           relationship_item = relationships_to_serialize[item]
-          raise ArgumentError, "Could not find included relationship '#{item}' on #{self.class.name}" if relationship_item.nil?
+          raise FastJsonapi::InvalidIncludeError, "Could not find included relationship '#{item}' on #{self.class.name}" if relationship_item.nil?
           next unless relationship_item.include_relationship?(record, params)
           unless relationship_item.polymorphic.is_a?(Hash)
             record_type = relationship_item.record_type

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -107,7 +107,7 @@ module FastJsonapi
 
         includes_list.each_with_object([]) do |(item, subitems), included_records|
           relationship_item = relationships_to_serialize[item]
-          raise ArgumentError, "Could not find relationship '#{item}' on #{self.class.name}" if relationship_item.nil?
+          raise ArgumentError, "Could not find included relationship '#{item}' on #{self.class.name}" if relationship_item.nil?
           next unless relationship_item.include_relationship?(record, params)
           unless relationship_item.polymorphic.is_a?(Hash)
             record_type = relationship_item.record_type

--- a/spec/lib/object_serializer_include_spec.rb
+++ b/spec/lib/object_serializer_include_spec.rb
@@ -55,8 +55,15 @@ describe FastJsonapi::ObjectSerializer do
     end
   end
 
-  it 'fails validation if an included item is not a relationship on the object' do
-    expect { MovieSerializer.new(movie, include: [:foo]).serializable_hash }.to raise_error(ArgumentError)
-    expect { MovieSerializer.new(movie, include: { actors: :foo }).serializable_hash }.to raise_error(ArgumentError)
+  describe 'validation' do
+    it 'raises an exception if an included item is not a relationship on the object' do
+      expect { MovieSerializer.new(movie, include: [:foo]).serializable_hash }.to raise_error(FastJsonapi::InvalidIncludeError)
+      expect { MovieSerializer.new(movie, include: { actors: :foo }).serializable_hash }.to raise_error(FastJsonapi::InvalidIncludeError)
+    end
+
+    it 'properly validates dynamic (e.g. polymorphic) relationships' do
+      expect { TheaterSerializer.new(theater, include: { snacks: :supplier }).serializable_hash }.to_not raise_error
+      expect { TheaterSerializer.new(theater, include: { snacks: :foo }).serializable_hash }.to raise_error(FastJsonapi::InvalidIncludeError)
+    end
   end
 end

--- a/spec/lib/object_serializer_include_spec.rb
+++ b/spec/lib/object_serializer_include_spec.rb
@@ -54,4 +54,9 @@ describe FastJsonapi::ObjectSerializer do
       expect(has_included_type?(hash, :advertising_campaign)).to eq true
     end
   end
+
+  it 'fails validation if an included item is not a relationship on the object' do
+    expect { MovieSerializer.new(movie, include: [:foo]).serializable_hash }.to raise_error(ArgumentError)
+    expect { MovieSerializer.new(movie, include: { actors: :foo }).serializable_hash }.to raise_error(ArgumentError)
+  end
 end

--- a/spec/lib/object_serializer_include_spec.rb
+++ b/spec/lib/object_serializer_include_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe FastJsonapi::ObjectSerializer do
+  include_context 'movie class'
+
+  def has_included_type?(hash, type)
+    hash[:included].any? { |i| i[:type].to_sym == type }
+  end
+
+  describe '`include`' do
+    it 'can defined as symbols' do
+      hash = MovieSerializer.new(movie, include: [:actors, :advertising_campaign]).serializable_hash
+      expect(has_included_type?(hash, :actor)).to eq true
+      expect(has_included_type?(hash, :advertising_campaign)).to eq true
+      expect(has_included_type?(hash, :agency)).to eq false
+    end
+
+    it 'can be defined as strings' do
+      hash = MovieSerializer.new(movie, include: ['actors', 'advertising_campaign']).serializable_hash
+      expect(has_included_type?(hash, :actor)).to eq true
+      expect(has_included_type?(hash, :advertising_campaign)).to eq true
+      expect(has_included_type?(hash, :agency)).to eq false
+    end
+
+    describe 'nested relationships' do
+
+      it 'can be defined as dot notation' do
+        hash = MovieSerializer.new(movie, include: ['actors', 'actors.agency', 'actors.agency.state']).serializable_hash
+        expect(has_included_type?(hash, :actor)).to eq true
+        expect(has_included_type?(hash, :agency)).to eq true
+        expect(has_included_type?(hash, :state)).to eq true
+      end
+
+      it 'does not require the parent to be specified separately in dot notation' do
+        hash = MovieSerializer.new(movie, include: ['actors.agency.state']).serializable_hash
+        expect(has_included_type?(hash, :actor)).to eq true
+        expect(has_included_type?(hash, :agency)).to eq true
+        expect(has_included_type?(hash, :state)).to eq true
+      end
+
+      it 'can be specified as hashes' do
+        hash = MovieSerializer.new(movie, include: { actors: { agency: :state } }).serializable_hash
+        expect(has_included_type?(hash, :actor)).to eq true
+        expect(has_included_type?(hash, :agency)).to eq true
+        expect(has_included_type?(hash, :state)).to eq true
+      end
+    end
+
+    it 'can include any combination of notation' do
+      hash = MovieSerializer.new(movie, include: [{ actors: :agency }, :advertising_campaign, 'actors.agency.state' ]).serializable_hash
+      expect(has_included_type?(hash, :actor)).to eq true
+      expect(has_included_type?(hash, :agency)).to eq true
+      expect(has_included_type?(hash, :state)).to eq true
+      expect(has_included_type?(hash, :advertising_campaign)).to eq true
+    end
+  end
+end

--- a/spec/lib/serialization_core_spec.rb
+++ b/spec/lib/serialization_core_spec.rb
@@ -60,7 +60,7 @@ describe FastJsonapi::ObjectSerializer do
     end
 
     it 'serializes known included records only once' do
-      includes_list = [:actors]
+      includes_list = { actors: {} }
       known_included_objects = {}
       included_records = []
       [movie, movie].each do |record|

--- a/spec/shared/contexts/movie_context.rb
+++ b/spec/shared/contexts/movie_context.rb
@@ -167,6 +167,30 @@ RSpec.shared_context 'movie class' do
       attr_accessor :id
     end
 
+    class Theater
+      attr_accessor :id, :name, :snacks
+    end
+
+    class Popcorn
+      attr_accessor :id, :supplier_id
+
+      def supplier
+        Supplier.new.tap do |s|
+          s.id = supplier_id
+        end
+      end
+    end
+
+    class Candy
+      attr_accessor :id, :supplier_id
+
+      def supplier
+        Supplier.new.tap do |s|
+          s.id = supplier_id
+        end
+      end
+    end
+
     class OwnerSerializer
       include FastJsonapi::ObjectSerializer
     end
@@ -309,6 +333,24 @@ RSpec.shared_context 'movie class' do
     class AccountSerializer
       include FastJsonapi::ObjectSerializer
       set_type :account
+      belongs_to :supplier
+    end
+
+    class TheaterSerializer
+      include FastJsonapi::ObjectSerializer
+      set_type :theater
+      has_many :snacks, polymorphic: true
+    end
+
+    class PopcornSerializer
+      include FastJsonapi::ObjectSerializer
+      set_type :popcorn
+      belongs_to :supplier
+    end
+
+    class CandySerializer
+      include FastJsonapi::ObjectSerializer
+      set_type :candy
       belongs_to :supplier
     end
 
@@ -474,6 +516,22 @@ RSpec.shared_context 'movie class' do
     s.id = 1
     s.account_id = 1
     s
+  end
+
+  let(:theater) do
+    t = Theater.new
+    t.id = 1
+    t.snacks = [
+      Popcorn.new.tap do |p|
+        p.id = 3
+        p.supplier_id = 4
+      end,
+      Candy.new.tap do |p|
+        p.id = 7
+        p.supplier_id = 5
+      end
+    ]
+    t
   end
 
   def build_movies(count)


### PR DESCRIPTION
* Fixes #41.  Originally, `include` would be validated up front every time a serializer is instantiated, which (a) takes time, and (b) is limited to only validating static relationships, so polymorphic, object blocks, serializer blocks, etc. could not be validated.  Now, instead, it will simply assume that `include` is valid, attempt the serialization, and fail if the relationship does not exist.

* Per @stas's comment in #41, the validation raises a custom exception instead of a plain old `ArgumentError`.  I created an `errors.rb` file so that we can have a common place to define custom exceptions, like most gems do.

* Improved the syntax of `include` to be much more flexible.  Now you can specify strings, symbols, arrays, and hashes (for nested relationships).  Dot notation still works, and in fact is improved because now you don't need to specify the parents separately, e.g. `[ :actors, :'actors.agency' ]`.  Now you can simply say `'actors.agency'`, and it implicitly includes `actors` too.  But best of all, you can now write this as `{ actors: [ :agency ] }`, or simply `{ actors: :agency }`.  In general, this should also be a performance improvement, because the code originally parsed `include` and split strings during each iteration.  Now it parses it once up front, builds a nice relationship tree, and passes the proper branch of the tree to each relationship during serialization.