### PR TITLE
Fix #attribute with lambda

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -214,10 +214,7 @@ module FastJsonapi
         self.attributes_to_serialize = {} if self.attributes_to_serialize.nil?
 
         # to support calling `attribute` with a lambda, e.g `attribute :key, ->(object) { ... }`
-        if attributes_list.size == 2 && attributes_list[1].is_a?(Proc)
-          block = attributes_list[1]
-          attributes_list = [attributes_list[0]]
-        end
+        block = attributes_list.pop if attributes_list.last.is_a?(Proc)
 
         attributes_list.each do |attr_name|
           method_name = attr_name

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -213,6 +213,12 @@ module FastJsonapi
         options = attributes_list.last.is_a?(Hash) ? attributes_list.pop : {}
         self.attributes_to_serialize = {} if self.attributes_to_serialize.nil?
 
+        # to support calling `attribute` with a lambda, e.g `attribute :key, ->(object) { ... }`
+        if attributes_list.size == 2 && attributes_list[1].is_a?(Proc)
+          block = attributes_list[1]
+          attributes_list = [attributes_list[0]]
+        end
+
         attributes_list.each do |attr_name|
           method_name = attr_name
           key = run_key_transform(method_name)

--- a/spec/lib/object_serializer_class_methods_spec.rb
+++ b/spec/lib/object_serializer_class_methods_spec.rb
@@ -425,6 +425,23 @@ describe FastJsonapi::ObjectSerializer do
         expect(serializable_hash[:data][:attributes][:released_in_year]).to eq movie.release_year
       end
     end
+
+    context 'with lambda' do
+      before do
+        movie.release_year = 2008
+        MovieSerializer.attribute :released_in_year, &:release_year
+        MovieSerializer.attribute :name, ->(object) { object.local_name }
+      end
+
+      after do
+        MovieSerializer.attributes_to_serialize.delete(:released_in_year)
+      end
+
+      it 'returns correct hash when serializable_hash is called' do
+        expect(serializable_hash[:data][:attributes][:name]).to eq "english #{movie.name}"
+        expect(serializable_hash[:data][:attributes][:released_in_year]).to eq movie.release_year
+      end
+    end
   end
 
   describe '#meta' do

--- a/spec/lib/object_serializer_class_methods_spec.rb
+++ b/spec/lib/object_serializer_class_methods_spec.rb
@@ -418,6 +418,7 @@ describe FastJsonapi::ObjectSerializer do
 
       after do
         MovieSerializer.attributes_to_serialize.delete(:released_in_year)
+        MovieSerializer.attributes_to_serialize.delete(:name)
       end
 
       it 'returns correct hash when serializable_hash is called' do
@@ -435,6 +436,7 @@ describe FastJsonapi::ObjectSerializer do
 
       after do
         MovieSerializer.attributes_to_serialize.delete(:released_in_year)
+        MovieSerializer.attributes_to_serialize.delete(:name)
       end
 
       it 'returns correct hash when serializable_hash is called' do


### PR DESCRIPTION
I just noticed calling `attribute` with a lambda does not work: `attribute :key, ->(object) { ... }` and added a failing spec with a simple fix.

Since some work has been done recently to allow lambdas in addition to procs at various places I wonder if this should work here, too?