### PR TITLE
`polymprhic: true` makes serializer proc being ignored

### DIFF
--- a/lib/fast_jsonapi/relationship.rb
+++ b/lib/fast_jsonapi/relationship.rb
@@ -67,13 +67,13 @@ module FastJsonapi
       if @static_serializer
         return @static_serializer
 
+      elsif serializer.is_a?(Proc)
+        FastJsonapi.call_proc(serializer, record, serialization_params)
+
       elsif polymorphic
         name = polymorphic[record.class] if polymorphic.is_a?(Hash)
         name ||= record.class.name
         serializer_for_name(name)
-
-      elsif serializer.is_a?(Proc)
-        FastJsonapi.call_proc(serializer, record, serialization_params)
 
       elsif object_block
         serializer_for_name(record.class.name)


### PR DESCRIPTION
## What is the current behavior?

Currently it is not possible to define the serializer for a polymorphic relationship, eg. `has_many :assets polymorphic: true, serializer: proc { ...}`. See the failing spec in this MR.

## What is the new behavior?

This just adds a failing spec to illustrate the behavior. I don't know if this behavior is correct and just bad usage of options or if there is really something wrong.

## Questions

Since I did not dive into this part of the codebase and haven't used polymorphic relationships a lot, maybe somebody with the idea of how it should work can answer this questions:

- Is this behavior correct? Should you never use `polymorphic: true` together with `serializer` and this is simply wrong usage?
- What is the purpose of `polymorphic` now anyways? Is it obsolete now and you should only use `serializer: ...` for polymorphic relationships? Or is there something that `polymorphic` does that cannot be done with `serializer`? Maybe setting a custom `record_type` which differs from the serializer's class, so you might still need it?

## Checklist

Please make sure the following requirements are complete:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)
