### PR TITLE
Check #each instead of #size for is_collection?

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -106,7 +106,7 @@ module FastJsonapi
     def is_collection?(resource, force_is_collection = nil)
       return force_is_collection unless force_is_collection.nil?
 
-      resource.respond_to?(:size) && !resource.respond_to?(:each_pair)
+      resource.respond_to?(:each) && !resource.respond_to?(:each_pair)
     end
 
     class_methods do


### PR DESCRIPTION
See if a resource responds to 'each' instead of 'size' as
things other than collections can respond to 'size' (e.g. File instance)

## What is the current behavior?
https://github.com/Netflix/fast_jsonapi/issues/459

An object that responds to 'size' is treated as a collection (even if it is not) and the code later causes an error trying to call 'each'
<!-- Please describe the current behavior that you are modifying, or link to a
  relevant issue. -->

## What is the new behavior?
An object that responds to 'size' isn't treated as a collection (unless it responds to 'each')
<!-- Please describe the behavior or changes that are being added here. -->

## Checklist

Please make sure the following requirements are complete:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)
