### PR TITLE
Publish tagged releases on GPR.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,16 @@ jobs:
 
     - name: Runs code QA and tests
       run: rspec
+
+    - name: Publish to GPR
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      run: |
+        mkdir -p $HOME/.gem
+        touch $HOME/.gem/credentials
+        chmod 0600 $HOME/.gem/credentials
+        printf -- "---\n:github: Bearer ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+        gem build
+        gem push --KEY github --host https://rubygems.pkg.github.com/${OWNER} *.gem
+      env:
+        GEM_HOST_API_KEY: ${{secrets.GPR_AUTH_TOKEN}}
+        OWNER: fast_jsonapi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2020-04-29
+### Added
+- Serializer option support for procs (#32)
+- JSON serialization API method is now implementable (#44)
+
+### Changed
+- Support for polymorphic `id_method_name` (#17)
+- Relationships support for `&:proc` syntax (#58)
+- Conditional support for procs (#59)
+- Attribute support for procs (#67)
+- Refactor caching support (#52)
+- `is_collection?` is safer for objects (#18)
+
+### Removed
+- `serialized_json` is now deprecated (#44)
+
 ## [1.6.0] - 2019-11-04
 ### Added
 - Allow relationship links to be delcared as a method ([#2](https://github.com/fast-jsonapi/fast_jsonapi/pull/2))
@@ -17,6 +33,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Define ObjectSerializer.set_key_transform mapping as a constant ([#7](https://github.com/fast-jsonapi/fast_jsonapi/pull/7))
 - Optimize SerializtionCore.remaining_items by taking from original array ([#9](https://github.com/fast-jsonapi/fast_jsonapi/pull/9))
 - Optimize ObjectSerializer.deep_symbolize by using each_with_object instead of Hash[map] ([#6](https://github.com/fast-jsonapi/fast_jsonapi/pull/6))
-
-[Unreleased]: https://github.com/fast-jsonapi/fast_jsonapi/compare/dev...HEAD
-[1.6.0]: https://github.com/fast-jsonapi/fast_jsonapi/compare/1.5...1.6.0

--- a/lib/fast_jsonapi/version.rb
+++ b/lib/fast_jsonapi/version.rb
@@ -1,3 +1,3 @@
 module FastJsonapi
-  VERSION = '1.6.0'
+  VERSION = '1.7.0'
 end


### PR DESCRIPTION
## What is the current behavior?

We need a release.

## What is the new behavior?

The releases (any tag on master) are automated and published to our GPR:
https://github.com/orgs/fast-jsonapi/packages?package_type=RubyGems

I also updated the changelog.

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
