### PR TITLE
fix(ObjectSerializer): pass to_json arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.1] - 2020-05-01
+### Fixed
+- ObjectSerializer#serialized_json accepts arguments for to_json (#80)
+
 ## [1.7.0] - 2020-04-29
 ### Added
 - Serializer option support for procs (#32)

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -72,12 +72,12 @@ module FastJsonapi
       serializable_hash
     end
 
-    def serialized_json
+    def serialized_json(*args)
       warn(
         'DEPRECATION: `#serialized_json` will be removed in the next release. '\
         'More details: https://github.com/fast-jsonapi/fast_jsonapi/pull/44'
       )
-      serializable_hash.to_json
+      serializable_hash.to_json(*args)
     end
     alias to_json serialized_json
 

--- a/lib/fast_jsonapi/version.rb
+++ b/lib/fast_jsonapi/version.rb
@@ -1,3 +1,3 @@
 module FastJsonapi
-  VERSION = '1.7.0'.freeze
+  VERSION = '1.7.1'.freeze
 end


### PR DESCRIPTION
## What is the current behavior?

ObjectSerializer#serialize_json does not accept arguments for to_json alias

## What is the new behavior?

ObjectSerializer#serialize_json accepts arguments for to_json alias.

Note the allowed arguments in the original to_json https://apidock.com/rails/Hash/to_json

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
