### PR TITLE
fix(Relationship): do not set static_record_type for polymorphic relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+### Fixed
+- Relationship#record_type_for does not assign static record type for polymorphic relationships (#83)
+
 ## [1.7.1] - 2020-05-01
 ### Fixed
 - ObjectSerializer#serialized_json accepts arguments for to_json (#80)

--- a/lib/fast_jsonapi/relationship.rb
+++ b/lib/fast_jsonapi/relationship.rb
@@ -212,8 +212,13 @@ module FastJsonapi
     end
 
     def compute_static_record_type
-      return run_key_transform(record_type) if record_type
-      return run_key_transform(@static_serializer.record_type) if @static_serializer
+      if polymorphic
+        nil
+      elsif record_type
+        run_key_transform(record_type)
+      elsif @static_serializer
+        run_key_transform(@static_serializer.record_type)
+      end
     end
   end
 end


### PR DESCRIPTION
## What is the current behavior?

Specifying `:polymorphic` on a `belongs_to` relationship gives a static `record_type`.

## What is the new behavior?

Polymorphic relationships do not set a static `record_type`.  This allows a lookup of each record type.

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
