### PR TITLE
Remove ObjectSerializer#serialized_json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- Remove `ObjectSerializer#serialized_json`
+- Remove `ObjectSerializer#serialized_json` (#91)
 
 ## [1.7.2] - 2020-05-18
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Remove `ObjectSerializer#serialized_json`
+
 ## [1.7.2] - 2020-05-18
 ### Fixed
 - Relationship#record_type_for does not assign static record type for polymorphic relationships (#83)

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -72,15 +72,6 @@ module FastJsonapi
       serializable_hash
     end
 
-    def serialized_json(*args)
-      warn(
-        'DEPRECATION: `#serialized_json` will be removed in the next release. '\
-        'More details: https://github.com/fast-jsonapi/fast_jsonapi/pull/44'
-      )
-      serializable_hash.to_json(*args)
-    end
-    alias to_json serialized_json
-
     private
 
     def process_options(options)

--- a/lib/fast_jsonapi/version.rb
+++ b/lib/fast_jsonapi/version.rb
@@ -1,3 +1,3 @@
 module FastJsonapi
-  VERSION = '1.7.2'.freeze
+  VERSION = '2.0.0'.freeze
 end


### PR DESCRIPTION
Removes the deprecated `ObjectSerializer#serialized_json`.  It's been a few months and the warnings are creating too much noise in our logs, it's time to say goodbye!