### PR TITLE
Add serializer name to cache namespace

### DIFF
--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -94,29 +94,24 @@ module FastJsonapi
       #
       # @param options [Hash] default cache options
       # @param fieldset [Array, nil] passed fieldset values
-      # @param includes_list [Array, nil] passed included values
-      # @param params [Hash] the serializer params
+      # @param _includes_list [Array, nil] passed included values
+      # @param _params [Hash] the serializer params
       #
       # @return [Hash] processed options hash
-      # rubocop:disable Lint/UnusedMethodArgument
-      def record_cache_options(options, fieldset, includes_list, params)
-        return options unless fieldset
-
+      def record_cache_options(options, fieldset, _includes_list, _params)
         options = options ? options.dup : {}
-        options[:namespace] ||= 'jsonapi-serializer'
-
-        fieldset_key = fieldset.join('_')
-
-        # Use a fixed-length fieldset key if the current length is more than
-        # the length of a SHA1 digest
-        if fieldset_key.length > 40
-          fieldset_key = Digest::SHA1.hexdigest(fieldset_key)
+        namespace = [options[:namespace] ||= 'jsonapi-serializer']
+        if fieldset
+          fieldset_key = fieldset.join('_')
+          # Use a fixed-length fieldset key if the current length is more than
+          # the length of a SHA1 digest
+          fieldset_key = Digest::SHA1.hexdigest(fieldset_key) if fieldset_key.length > 40
+          namespace.push("fieldset:#{fieldset_key}")
         end
-
-        options[:namespace] = "#{options[:namespace]}-fieldset:#{fieldset_key}"
+        namespace.push("serializer:#{name.urlize}")
+        options[:namespace] = [namespace.compact.join('-')]
         options
       end
-      # rubocop:enable Lint/UnusedMethodArgument
 
       def id_from_record(record, params)
         return FastJsonapi.call_proc(record_id, record, params) if record_id.is_a?(Proc)


### PR DESCRIPTION
## Current Behaviour

When different serializations of the same object are created, the cache namespace and key used is the same, which can cause the wrong representation to be retrieved.

For example, if an "index" page for "Articles" uses a lightweight "preview" representation of each article to show a thumbnail image, and headline, but the "show" page uses a full serialization including the article content, metadata, author information, etc. then on navigating to the "show" page the cache will return the "preview" serialization.

The exception to this is a serialization using parse fieldsets, which modifies the cache namespace to avoid collisions between the default serialization and the serialization using a specified fieldset.

## New Behaviour

The name of the serializer being invoked is added to the namespace (in addition to the fieldset, if it exists), which will avoid these collisions.

## References

This should address these issues from the beforetime:

Netflix/fast_jsonapi/issues/300
Netflix/fast_jsonapi/issues/389
Netflix/fast_jsonapi/issues/394

