### PR TITLE
Remove relationships key when having fields with no relationships specified

### DIFF
--- a/spec/integration/attributes_fields_spec.rb
+++ b/spec/integration/attributes_fields_spec.rb
@@ -57,6 +57,29 @@ RSpec.describe JSONAPI::Serializer do
           .and(have_id(actor.movies[0].id))
           .and(have_jsonapi_attributes('release_year').exactly)
         )
+        expect(serialized['data'])
+        .to_not have_relationship('played_movies')
+      end
+    end
+
+    context 'with fields for the relationship' do
+      let(:params) do
+        {
+          fields: { actor: [:first_name, :played_movies] }
+        }
+      end
+
+      it do
+        expect(serialized['data'])
+          .to have_jsonapi_attributes(:first_name).exactly
+
+        expect(serialized['data'])
+        .to have_relationship('played_movies')
+        .with_data(
+          [
+            { 'id' => actor.movies[0].id, 'type' => 'movie' },
+          ]
+        )
       end
     end
   end


### PR DESCRIPTION
## What is the current behavior?

The `fields` option was filling the `relationships_hash` with an empty hash instead of not having it at all:
```ruby
        relationships = relationships.slice(*fieldset) if fieldset.present?
```
But you can have some cases where you do have fieldsets but none of those fieldsets are related to the relationships. Instead of having no relationships at all, you will have then an empty hash, even though if you specifically specified you didn't want and relationships in your fields option.
See issue : https://github.com/jsonapi-serializer/jsonapi-serializer/issues/167

## What is the new behavior?

IF there is a fieldset but that fieldset has no keys related to the relationships, the relationships_hash will return nil and will not be constructed.
IF there is a field with some keys related to the relationships, those keys will slice `relationships_to_serialize` to select the ones related
IF there is no fieldset, all the keys of the relationships are selected

## Checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)

## Disclaimer

This the first time I'm posting a PR for open source gem, but I'm doing my best! Looking forward for review / things to change.