### PR TITLE
Check has_one for instance variables as well

### DIFF
--- a/lib/extensions/has_one.rb
+++ b/lib/extensions/has_one.rb
@@ -9,7 +9,10 @@
     name = reflection.name
     mixin.class_eval <<-CODE, __FILE__, __LINE__ + 1
       def #{name}_id
-        # if an attribute is already defined with this methods name we should just use it
+        # if a variable is already defined with this methods name we should just use it
+        return instance_variable_get("@#{__method__}") if instance_variable_defined?("@#{__method__}")
+
+        # same with attributes
         return read_attribute(__method__) if has_attribute?(__method__)
         association(:#{name}).reader.try(:id)
       end


### PR DESCRIPTION
## What is the current behavior?

We have a model that relies on has_one with through and an attribute accessor to find that parent object, something like this:

```ruby
class User
  has_one :user_credit
  has_many :store_credits, through: :user_credit
end

class UserCredit
  belongs_to :user 
end

class StoreCredit
  belongs_to :user_credit
  has_one :user_credit, through: :user 

  validates_presence_of :user_credit_id

  attr_accessor :user_id

  before_validation :lookup_user_credit, if: -> { user_id.present? }

  def lookup_user_credit
    self.user_credit_id = UserCredit.find_or_create_by!(user_id: user_id).id
  end
end
```

and this extension breaks the lookup_user_credit because it is dynamically generating the reader function and only checking attributes and not instance variables. I dug through commit history in both this and the previous repo and I can't find the original reason this extension was added but I'm assuming its still needed? 

## What is the new behavior?

The change dynamically checks instance variables in the same fashion it is already checking attributes. 

I did not add a unit test because the current extension is not hit and I'm hoping that this is just straightforward and basic enough to not have to add an entire suite of fixtures and/or rely on real active record models within in spec here but let me know.

## Checklist

Please make sure the following requirements are complete:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)
