### PR TITLE
Bugfix: Prevent undefined method errors when include is provided

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -340,7 +340,9 @@ module FastJsonapi
         return if includes.blank?
 
         parse_includes_list(includes).each_key do |include_item|
-          relationship_to_include = relationships_to_serialize[include_item]
+          relationships = relationships_to_serialize || {}
+          relationship_to_include = relationships[include_item]
+
           raise(JSONAPI::Serializer::UnsupportedIncludeError.new(include_item, name)) unless relationship_to_include
 
           relationship_to_include.static_serializer # called for a side-effect to check for a known serializer class.

--- a/spec/integration/errors_spec.rb
+++ b/spec/integration/errors_spec.rb
@@ -21,5 +21,16 @@ RSpec.describe JSONAPI::Serializer do
           JSONAPI::Serializer::UnsupportedIncludeError, /bad_include is not specified as a relationship/
         )
     end
+
+    context 'when include is provided for a resource that does not have relationships' do
+      let(:user) { User.fake }
+
+      it do
+        expect { UserSerializer.new(user, include: ['bad_include']) }
+          .to raise_error(
+            JSONAPI::Serializer::UnsupportedIncludeError, /bad_include is not specified as a relationship/
+          )
+      end
+    end
   end
 end


### PR DESCRIPTION
## What is the current behavior?

When `include` is provided as an argument for a serializer that does not have any relationships defined, then an `undefined method [] for nil:NilClass` error is raised instead of the expected: `JSONAPI::Serializer::UnsupportedIncludeError`.
```ruby
u = User.fake
UserSerializer.new(user, include: ['bad_include']) # => <NoMethodError: undefined method `[]' for nil:NilClass>
```

## What is the new behavior?

When `include` is provided as an argument for a serializer that does not have any relationships defined, then `JSONAPI::Serializer::UnsupportedIncludeError` is returned:
```ruby
u = User.fake
UserSerializer.new(user, include: ['bad_include']) # => <JSONAPI::Serializer::UnsupportedIncludeError>
```

## Checklist

Please make sure the following requirements are complete:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)

## Refs
- https://github.com/jsonapi-serializer/jsonapi-serializer/issues/210