### PR TITLE
PoC pagination and filtering for included objects

### DIFF
--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -164,7 +164,7 @@ module FastJsonapi
       def get_included_records(record, includes_list, known_included_objects, fieldsets, params = {})
         return unless includes_list.present?
         return [] unless relationships_to_serialize
-
+binding.pry
         includes_list = parse_includes_list(includes_list)
 
         includes_list.each_with_object([]) do |include_item, included_records|

--- a/lib/jsonapi/serializer/trackable.rb
+++ b/lib/jsonapi/serializer/trackable.rb
@@ -33,7 +33,7 @@ module JSONAPI
       # @param object [Object] to find the serialization class for
       # @param mapping [Hash] custom map of model to serializer classes
       # @return [Class] of the serialization class
-      def for_object(object, mapping = nil)
+      def for_object(object, mapping = nil, options = {})
         if mapping.is_a?(Hash)
           return (
             mapping[object.class] || NotFoundError.new(object, mapping.values)
@@ -44,6 +44,7 @@ module JSONAPI
           return klass if klass.name == "#{object.class.name}Serializer"
         end
 
+        return options[:default_serializer] unless options[:default_serializer].nil?
         raise NotFoundError.new(object, serializers)
       end
 


### PR DESCRIPTION
**Disclaimer:** This is only a PoC and not production ready

Allow using query objects in call_proc_or_method to get included objects for the relationship.

This PR contains a concept that can be used to add pagination and filtering (including visibility scoping) to the JSON API specification.

This problem is discussed in various places, for instance:
- https://discuss.jsonapi.org/t/paginating-relationships-includes/820
- https://discuss.jsonapi.org/t/how-to-handle-an-excessive-number-of-included-resources/209/3

And here is described the potential resolution on the specification level: https://github.com/cloudcreativity/laravel-json-api/issues/319#issuecomment-471871757

The idea is to add a query object layer to the application to help scope the scope for the relationship.

