### PR TITLE
Relationships are not added if fields are listed for the main object

### DIFF
--- a/spec/integration/attributes_fields_spec.rb
+++ b/spec/integration/attributes_fields_spec.rb
@@ -51,12 +51,21 @@ RSpec.describe JSONAPI::Serializer do
       it do
         expect(serialized['data'])
           .to have_jsonapi_attributes(:first_name).exactly
+      end
 
+      it do
         expect(serialized['included']).to include(
           have_type('movie')
           .and(have_id(actor.movies[0].id))
           .and(have_jsonapi_attributes('release_year').exactly)
         )
+      end
+
+      it do
+        played_movies_rel = [{ 'id' => actor.movies[0].id, 'type' => 'movie' }]
+
+        expect(serialized['data'])
+          .to have_relationship('played_movies').with_data(played_movies_rel)
       end
     end
   end


### PR DESCRIPTION
## What is the current behavior?
Current implementation does not include the relationships if you set sparse fields for the main object.

```ruby
actor = Actor.fake
actor.movies = [Movie.fake]

# without sparse fields for the main object
ActorSerializer.new(
  actor,
  include: [:played_movies],
  fields: { movie: [:title] }
).serializable_hash.as_json

{
        "data" => {
                   "id" => "625f4b4b-778e-4057-8652-b9cffb756d63",
                 "type" => "actor",
           "attributes" => {
            "first_name" => "Katie",
             "last_name" => "Goodwin",
                 "email" => "minta.haley@goodwin.us"
        },
        "relationships" => { # <--- relationships are included
            "played_movies" => {
                 "data" => [
                    {
                          "id" => "a8e34cf8-a98e-41ae-8c36-78853ff542e7",
                        "type" => "movie"
                    }
                ],
                "links" => {
                    "movie_url" => "http://gusikowski.name"
                }
            }
        },
                 "meta" => {
            "email_length" => 22
        }
    },
    "included" => [
        {
                       "id" => "a8e34cf8-a98e-41ae-8c36-78853ff542e7",
                     "type" => "movie",
               "attributes" => {},
            "relationships" => {},
                    "links" => {
                "self" => "http://gusikowski.name"
            }
        }
    ]
}

# with sparse fields for the main object
ActorSerializer.new(
  actor,
  include: [:played_movies],
  fields: {
    actor: [:first_name], # <--- added first_name to the fields
    movie: [:title]
  }
).serializable_hash.as_json

{
        "data" => {
                   "id" => "625f4b4b-778e-4057-8652-b9cffb756d63",
                 "type" => "actor",
           "attributes" => {
            "first_name" => "Katie"
        },
        "relationships" => {}, # <--- relationships are not included
                 "meta" => {
            "email_length" => 22
        }
    },
    "included" => [
        {
                       "id" => "a8e34cf8-a98e-41ae-8c36-78853ff542e7",
                     "type" => "movie",
               "attributes" => {},
            "relationships" => {},
                    "links" => {
                "self" => "http://gusikowski.name"
            }
        }
    ]
}
```

If we wanted to keep the relationships we will have to add it to the actors fields like this

```ruby
ActorSerializer.new(
  actor,
  include: [:played_movies],
  fields: {
    actor: [:first_name, :played_movies], # <--- added played_movies to the fields
    movie: [:title]
}
).serializable_hash.as_json

{
        "data" => {
                   "id" => "625f4b4b-778e-4057-8652-b9cffb756d63",
                 "type" => "actor",
           "attributes" => {
            "first_name" => "Katie"
        },
        "relationships" => { # <--- relationships are included
            "played_movies" => {
                 "data" => [
                    {
                          "id" => "a8e34cf8-a98e-41ae-8c36-78853ff542e7",
                        "type" => "movie"
                    }
                ],
                "links" => {
                    "movie_url" => "http://gusikowski.name"
                }
            }
        },
                 "meta" => {
            "email_length" => 22
        }
    },
    "included" => [
        {
                       "id" => "a8e34cf8-a98e-41ae-8c36-78853ff542e7",
                     "type" => "movie",
               "attributes" => {},
            "relationships" => {},
                    "links" => {
                "self" => "http://gusikowski.name"
            }
        }
    ]
}
```

I don't think it makes sense that we return the included relationships but with no way to know which ones are associated with the main resource.

## What is the new behavior?

It does not look like the fieldset should affect the relationships at all.

Here is the result with the PR applied:

```ruby
ActorSerializer.new(
  actor,
  include: [:played_movies],
  fields: { actor: [:first_name], movie: [:title] }
).serializable_hash.as_json

{
        "data" => {
                   "id" => "6eb5350c-dd1d-4bf7-bbaf-ec07bc7328b0",
                 "type" => "actor",
           "attributes" => {
            "first_name" => "Edmundo"
        },
        "relationships" => {
            "played_movies" => { # <--- relationships are included
                 "data" => [
                    {
                          "id" => "ec569840-6b0f-4ab5-8cf9-d387819c94ca",
                        "type" => "movie"
                    }
                ],
                "links" => {
                    "movie_url" => "http://bartell.ca"
                }
            }
        },
                 "meta" => {
            "email_length" => 30
        }
    },
    "included" => [
        {
                       "id" => "ec569840-6b0f-4ab5-8cf9-d387819c94ca",
                     "type" => "movie",
               "attributes" => {},
            "relationships" => { # <--- relationships are included for the included resource
                                         "owner" => {
                    "data" => nil
                },
                                 "actor_or_user" => {
                    "data" => nil
                },
                                        "actors" => {
                     "data" => [],
                     "meta" => {
                        "count" => 0
                    },
                    "links" => {
                        "actors_self" => "http://bartell.ca",
                            "related" => "http://bartell.ca?-3417018165944528449"
                    }
                },
                                       "creator" => {
                    "data" => nil
                },
                              "actors_and_users" => {
                    "data" => []
                },
                      "dynamic_actors_and_users" => {
                    "data" => []
                },
                "auto_detected_actors_and_users" => {
                    "data" => []
                }
            },
                    "links" => {
                "self" => "http://bartell.ca"
            }
        }
    ]
}
```

related to https://github.com/jsonapi-serializer/jsonapi-serializer/issues/167 but I don't think the proposed fix is the right solution. That just hides the empty relationships but still includes the associated resources

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)
